### PR TITLE
Retrieve Frida server release directly by tag name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ __pycache__
 *.pyc
 .idea
 node_modules
+/build
+/*.egg-info
 pirogue_evidence_collector/frida-dynamic-hooks/*.json

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pirogue-evidence-collector (1.0.5) bookworm; urgency=medium
+
+  * Retrieve Frida server release directly by tag name on GitHub API
+
+ -- Etienne Maheux <contact@peren.gouv.fr>  Wed, 23 Jul 2025 18:21:29 +0200
+
 pirogue-evidence-collector (1.0.4) bookworm; urgency=medium
 
   * Increase the number of Frida releases we retrieve from GitHub
@@ -16,7 +22,7 @@ pirogue-evidence-collector (1.0.2) bookworm; urgency=medium
 
  -- U+039b <hello@pts-project.org>  Sun, 17 Nov 2024 16:40:49 +0100
 
-pirogue-evidence-collector (1.0.1) bookword; urgency=medium
+pirogue-evidence-collector (1.0.1) bookworm; urgency=medium
 
   * Automatically open the listening port on the isolated network
 

--- a/pirogue_evidence_collector/frida/server.py
+++ b/pirogue_evidence_collector/frida/server.py
@@ -5,34 +5,38 @@ import requests
 
 
 FRIDA_SERVER_LATEST_RELEASE_URL = 'https://api.github.com/repos/frida/frida/releases/latest'
-FRIDA_SERVER_RELEASES_URL = 'https://api.github.com/repos/frida/frida/releases?per_page=50'
+FRIDA_SERVER_RELEASE_BY_TAG_URL = 'https://api.github.com/repos/frida/frida/releases/tags/{TAG}'
 log = logging.getLogger(__name__)
 
 
 class FridaServer:
     @staticmethod
-    def download_frida_server(arch: str, output_file, platform: str, client_version: str):
-        found = False
+    def download_frida_server(arch: str, output_file: str, platform: str, client_version: str):
         if not arch:
             log.error(f'Unable to determine device ABI, please install Frida server manually at {output_file}')
-            return 
-        releases = requests.get(FRIDA_SERVER_RELEASES_URL).json()
-        for release in releases:
-            tag_name = release.get('tag_name')
-            if tag_name == client_version:
-                for asset in release.get('assets'):
-                    asset_name = asset.get('name')
-                    if 'server' in asset_name and f'{platform}-{arch}.xz' in asset_name:
-                        found = True
-                        log.info(f'Downloading {asset_name}...')
-                        xz_file = requests.get(asset['browser_download_url'])
-                        log.info(f'Extracting {asset_name}...')
-                        server_binary = lzma.decompress(xz_file.content)
-                        log.info(f'Writing {asset_name} to {output_file}...')
-                        with open(output_file, mode='wb') as out:
-                            out.write(server_binary)
-                            out.flush()
-                        return
-        if not found:
-            log.error(f'Unable to find frida-server version {client_version} in GitHub releases. Please install it by hand at /data/local/tmp/frydaxx-server and make it executable using chmod +x.')
-            raise Exception(f'Unable to find frida-server version {client_version} in GitHub releases.')
+            return
+        resp = requests.get(FRIDA_SERVER_RELEASE_BY_TAG_URL.format(TAG=client_version))
+        try:
+            resp.raise_for_status()
+            release = resp.json()
+            assert release.get('tag_name') == client_version
+            for asset in release['assets']:
+                asset_name = asset['name']
+                if 'server' in asset_name and f'{platform}-{arch}.xz' in asset_name:
+                    log.info(f'Downloading {asset["browser_download_url"]}...')
+                    xz_file = requests.get(asset['browser_download_url'])
+                    xz_file.raise_for_status()
+                    log.info(f'Extracting {asset_name}...')
+                    server_binary = lzma.decompress(xz_file.content)
+                    log.info(f'Writing {asset_name} to {output_file}...')
+                    with open(output_file, mode='wb') as out:
+                        out.write(server_binary)
+                        out.flush()
+                    return
+            raise FileNotFoundError((arch, platform, client_version))
+        except Exception as e:
+            log.error(
+                f'Unable to find frida-server version {client_version} in GitHub releases. '
+                'Please install it by hand at /data/local/tmp/frydaxx-server and make it executable using chmod +x.'
+            )
+            raise Exception(f'Unable to find frida-server version {client_version} in GitHub releases.') from e

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pirogue-evidence-collector",
-    version="1.0.4",
+    version="1.0.5",
     author="U+039b",
     author_email="hello@pts-project.org",
     description="A set of tools to collect evidence from mobile devices",


### PR DESCRIPTION
Use Github API endpoint to get release by tag name instead of looping on all releases